### PR TITLE
Make caching work by removing comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: |
-          ~/go/pkg/mod              # Module download cache
-          ~/.cache/go-build         # Build cache (Linux)
-          ~/Library/Caches/go-build # Build cache (Mac)
-          '%LocalAppData%\go-build' # Build cache (Windows)
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,11 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ You can also include Go's build cache, to improve incremental builds:
 - uses: actions/cache@v2
   with:
     path: |
-      ~/go/pkg/mod              # Module download cache
-      ~/.cache/go-build         # Build cache (Linux)
-      ~/Library/Caches/go-build # Build cache (Mac)
-      '%LocalAppData%\go-build' # Build cache (Windows)
+      ~/go/pkg/mod
+      ~/.cache/go-build
+      ~/Library/Caches/go-build
+      %LocalAppData%\go-build
     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
     restore-keys: |
       ${{ runner.os }}-go-

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ You can also include Go's build cache, to improve incremental builds:
 ```yaml
 - uses: actions/cache@v2
   with:
+    # In order:
+    # * Module download cache
+    # * Build cache (Linux)
+    # * Build cache (Mac)
+    # * Build cache (Windows)
     path: |
       ~/go/pkg/mod
       ~/.cache/go-build


### PR DESCRIPTION
Path is a multiline string, which includes comments in its value. This
means that the caching was not working at all, because it would include
the comment in the path. Here I'm removing the comments, which fixes the
caching so it works.

You might have to change the cache key for your own repository to make it work there. You can check that the caching was broken [here](https://yaml-online-parser.appspot.com/?yaml=on%3A+%5Bpush%2C+pull_request%5D%0Aname%3A+Test%0Ajobs%3A%0A++test%3A%0A++++strategy%3A%0A++++++matrix%3A%0A++++++++go-version%3A+%5B1.14.x%2C+1.15.x%5D%0A++++++++os%3A+%5Bubuntu-latest%2C+macos-latest%2C+windows-latest%5D%0A++++runs-on%3A+%24%7B%7B+matrix.os+%7D%7D%0A++++steps%3A%0A++++-+name%3A+Install+Go%0A++++++uses%3A+actions%2Fsetup-go%40v2%0A++++++with%3A%0A++++++++go-version%3A+%24%7B%7B+matrix.go-version+%7D%7D%0A++++-+name%3A+Checkout+code%0A++++++uses%3A+actions%2Fcheckout%40v2%0A++++-+name%3A+Test%0A++++++run%3A+go+test+.%2F...%0A%0A++test-cache%3A%0A++++runs-on%3A+ubuntu-latest%0A++++steps%3A%0A++++-+name%3A+Install+Go%0A++++++uses%3A+actions%2Fsetup-go%40v2%0A++++++with%3A%0A++++++++go-version%3A+1.15.x%0A++++-+name%3A+Checkout+code%0A++++++uses%3A+actions%2Fcheckout%40v2%0A++++-+uses%3A+actions%2Fcache%40v2%0A++++++with%3A%0A++++++++path%3A+%7C%0A++++++++++~%2Fgo%2Fpkg%2Fmod++++++++++++++%23+Module+download+cache%0A++++++++++~%2F.cache%2Fgo-build+++++++++%23+Build+cache+(Linux)%0A++++++++++~%2FLibrary%2FCaches%2Fgo-build+%23+Build+cache+(Mac)%0A++++++++++%27%25LocalAppData%25%5Cgo-build%27+%23+Build+cache+(Windows)%0A++++++++key%3A+%24%7B%7B+runner.os+%7D%7D-go-%24%7B%7B+hashFiles(%27**%2Fgo.sum%27)+%7D%7D%0A++++++++restore-keys%3A+%7C%0A++++++++++%24%7B%7B+runner.os+%7D%7D-go-%0A++++-+name%3A+Test%0A++++++run%3A+go+test+.%2F...&type=json) and see how it was being parsed. I figured out it was broken because the restore step always said `Cache Size: ~0 MB (22 B)`