### PR TITLE
Update setup-go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,4 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: 1.20.x
-        cache-dependency-path: go.sum
     - run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,32 +8,18 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/checkout@v3
     - run: go test ./...
 
   test-cache:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
       with:
         go-version: 1.20.x
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        # * Build cache (Windows)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          ~\AppData\Local\go-build
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ matrix.go-version }}-
+        cache-dependency-path: go.sum
     - run: go test ./...


### PR DESCRIPTION
This PR updates `setup-go` to v4 and uses caching function by `setup-go`.